### PR TITLE
Fixed an error

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -118,8 +118,8 @@ Um zum Beispiel ein Bild aus den von einer Anfrage gelieferten Binärdaten zu er
 können Sie den folgenden Code benutzen::
 
     >>> from PIL import Image
-    >>> from StringIO import StringIO
-    >>> i = Image.open(StringIO(r.content))
+    >>> from io import BytesIO
+    >>> i = Image.open(BytesIO(r.content))
 
 
 JSON-basierte Antwortdaten


### PR DESCRIPTION
If you use StringIO will get an error: initial_value must be str or None, not bytes.
The English version is BytesIO.